### PR TITLE
14 Fix camelCase function

### DIFF
--- a/squeakuences.py
+++ b/squeakuences.py
@@ -97,11 +97,11 @@ def stripSequenceId(line):
 
 def camelCase(sequenceId):
   capList = []
-  wordList = re.split(r'[\s_-]', sequenceId)
+  wordList = re.split(r'([^a-zA-Z0-9])', sequenceId)
   for word in wordList:
     capWord = word[:1].upper() + word[1:]
     capList.append(capWord)
-  camelCaseSequence = ' '.join(capList)
+  camelCaseSequence = ''.join(capList)
   return camelCaseSequence
 
 def removeSpaces(sequenceId):

--- a/test_squeakuences.py
+++ b/test_squeakuences.py
@@ -37,7 +37,7 @@ class TestFileMethods(fake_filesystem_unittest.TestCase):
 
     self.assertIn('>Test1_AlphaBeta\n', contents)
     self.assertIn('ABCD\n', contents)
-    self.assertIn('>Test1_Zetaeta\n', contents)
+    self.assertIn('>Test1_ZetaEta\n', contents)
     self.assertIn('IJKLMNOP\n', contents)
 
   # Does resolveInput determine if a file path or directory path was given in the -i argument
@@ -137,10 +137,16 @@ class TestSequenceMethods(unittest.TestCase):
     funcOutput = 'Galgal_14-3-3 protein gamma'
     self.assertEqual(squeakuences.stripSequenceId(funcInput), funcOutput)
 
-  # Does camelCase captitalize all the words in a sequence id
+  # Does camelCase captitalize all the words in a sequence id and keep separators
   def test_camelCase(self):
-    input_sequence = 'Galgal_BTB/POZ domain-containing protein KCTD12'
-    self.assertEqual(squeakuences.camelCase(input_sequence), 'Galgal BTB/POZ Domain Containing Protein KCTD12')
+    input1 = 'Galgal_BTB/POZ domain-containing protein KCTD12'
+    input2 = 'alpha[beta](gamma)'
+    input3 = 'alpha beta, gamma'
+    input4 = 'alpha-beta_gamma'
+    self.assertEqual(squeakuences.camelCase(input1), 'Galgal_BTB/POZ Domain-Containing Protein KCTD12')
+    self.assertEqual(squeakuences.camelCase(input2), 'Alpha[Beta](Gamma)')
+    self.assertEqual(squeakuences.camelCase(input3), 'Alpha Beta, Gamma')
+    self.assertEqual(squeakuences.camelCase(input4), 'Alpha-Beta_Gamma')
 
   # Does removeSpaces remove whitespace
   def test_removeSpaces(self):


### PR DESCRIPTION
camelCase function now separates on all non-alphanumeric characters, capitalizes the words, and joins everything back together keeping the separators (any non-alphanumeric characters including parenthesis, brackets, white space, etc.) Appropriate tests also added in test file.