### PR TITLE
Allow relative path for input and output args

### DIFF
--- a/squeakuences.py
+++ b/squeakuences.py
@@ -14,13 +14,12 @@ import glob
 def main():
   parser = setupParser()
   args = parseArguments(parser)
-  write = args.output
 
-  inputType = resolveInput(args.input)
-  toProcess = inputList(inputType, args.input)
+  inputType, inputPath = resolveInput(args.input)
+  toProcess = inputList(inputType, inputPath)
   
   for file in toProcess:
-    squeakify(file, write)
+    squeakify(file, args.output)
 
 def squeakify(file, write):
   sequenceIdCount = 0
@@ -59,10 +58,22 @@ def squeakify(file, write):
 
 def resolveInput(userInput):
   if os.path.isfile(userInput):
-    return 'File'
+    return 'File', userInput
   
   if os.path.isdir(userInput):
-    return 'Directory'
+    fullDirPath = checkDirPath(userInput)
+    return 'Directory', fullDirPath
+  
+def checkDirPath(userInput):
+  if os.path.isabs(userInput):
+    return userInput
+  else:
+    cwd = os.getcwd()
+    if cwd == '/':
+      fullPath = '/' + userInput
+    else:
+      fullPath =  os.getcwd() + '/' + userInput
+  return fullPath
   
 def inputList(type, userInput):
   toSqueakify = []

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -193,8 +193,8 @@ def writeModIdFile(faFileName, idDictInput):
 def setupParser():
     parser = argparse.ArgumentParser()
     # Add parser arguments. ex: parser.add_argument('-l', '--long_name', help='What is it for?', required=True/False)
-    parser.add_argument('-i', '--input', help='Input file(s) to clean. This can be the full path or relative to the squeakuences file location.', required=True)
-    parser.add_argument('-o', '--output', help='Output Location This can be the full path or relative to the squeakuences file location.', required=True)
+    parser.add_argument('-i', '--input', help='Path to file(s) to clean. This can be the full path or relative to the squeakuences file location.', required=True)
+    parser.add_argument('-o', '--output', help='Path to ouput folder. This can be the full path or relative to the squeakuences file location. This directory must exist prior to running.', required=True)
     # add arg for chop function length
     return parser
   

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -193,8 +193,8 @@ def writeModIdFile(faFileName, idDictInput):
 def setupParser():
     parser = argparse.ArgumentParser()
     # Add parser arguments. ex: parser.add_argument('-l', '--long_name', help='What is it for?', required=True/False)
-    parser.add_argument('-i', '--input', help='Input file(s) to clean', required=True)
-    parser.add_argument('-o', '--output', help='Output Location', required=True)
+    parser.add_argument('-i', '--input', help='Input file(s) to clean. This can be the full path or relative to the squeakuences file location.', required=True)
+    parser.add_argument('-o', '--output', help='Output Location This can be the full path or relative to the squeakuences file location.', required=True)
     # add arg for chop function length
     return parser
   

--- a/test_squeakuences.py
+++ b/test_squeakuences.py
@@ -21,8 +21,14 @@ class TestFileMethods(fake_filesystem_unittest.TestCase):
     if not os.path.exists('/myFiles/test3.faa'):
       self.fs.create_file('/myFiles/test3.faa')
 
-    if not os.path.exists('/myFiles/test4.fa'):
-      self.fs.create_file('/myFiles/test4.fa')
+    if not os.path.exists('/myFiles/faFiles/test4.fa'):
+      self.fs.create_file('/myFiles/faFiles/test4.fa')
+
+    if not os.path.exists('/myFiles/faFiles/test5.fa'):
+      self.fs.create_file('/myFiles/faFiles/test5.fa')
+
+    if not os.path.exists('/directory2/test6.faa'):
+      self.fs.create_file('/directory2/test6.faa')
 
     if not os.path.exists('/OUT'):
       self.fs.create_dir('/OUT')
@@ -43,14 +49,20 @@ class TestFileMethods(fake_filesystem_unittest.TestCase):
   # Does resolveInput determine if a file path or directory path was given in the -i argument
   def test_resolveInput(self):
     self.setUp()
-    self.assertEqual(squeakuences.resolveInput('test1.fa'), 'File')
-    self.assertEqual(squeakuences.resolveInput('/myFiles'), 'Directory')
+    self.assertEqual(squeakuences.resolveInput('test1.fa'), ('File', 'test1.fa'))
+    self.assertEqual(squeakuences.resolveInput('/myFiles'), ('Directory', '/myFiles'))
+
+  # Does checkDirPath complete the directory path based on current working directory
+  def test_checkDirPath(self):
+    self.setUp()
+    self.assertEqual(squeakuences.checkDirPath('myFiles/faFiles'), '/myFiles/faFiles')
+    self.assertEqual(squeakuences.checkDirPath('/myFiles/faFiles'), '/myFiles/faFiles')
 
   # Does inputList generate a list of files based on the user input
   def test_inputList(self):
     self.setUp()
     self.assertEqual(squeakuences.inputList('File', 'test1.fa'), ['test1.fa'])
-    self.assertEqual(squeakuences.inputList('Directory', '/myFiles'), ['/myFiles/test2.fa', '/myFiles/test3.faa', '/myFiles/test4.fa'])
+    self.assertEqual(squeakuences.inputList('Directory', '/myFiles'), ['/myFiles/test2.fa', '/myFiles/test3.faa'])
 
   # Does loadFile load file properly
   def test_loadFile(self):


### PR DESCRIPTION
Added handling for various user inputs into -i and -o arguments. Users can now either give an absolute or relative path to the squeakuences.py file. This can end with a '/' or not. It does not seem to affect the script.