### PR TITLE
issue 37 - additional file types

### DIFF
--- a/squeakuences.py
+++ b/squeakuences.py
@@ -30,7 +30,7 @@ def main():
 
   inputType = resolveInput(inputPath)
   print('You\'ve input a ' + inputType + '.')
-  toProcess = inputList(inputType, inputPath)
+  toProcess = inputList(inputType, inputPath, fileExtension)
   fileNameList = getFaNameExt(toProcess)
   print('The following file(s) will be cleaned: ' + str(fileNameList))
   print('--------------------------------')
@@ -148,12 +148,12 @@ def checkDirPath(userInput):
 #####################################################
 # COLLECT FILES                                     #
 #####################################################
-def inputList(type, userInput):
+def inputList(type, userInput, ext):
   toSqueakify = []
   if type == 'file':
     toSqueakify.append(userInput)
   if type == 'directory':
-    toSqueakify = glob.glob(userInput + '/*.fa*')
+    toSqueakify = glob.glob(userInput + '/*' + ext)
   for file in toSqueakify:
     index = toSqueakify.index(file)
     toSqueakify[index] = os.path.abspath(file)

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -108,6 +108,7 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
+  parser.add_argument('-e', '--fileExt', metavar='.ext', help='When activated, Squeakuences will collect files with the given extension. Only one extension type is accepted at this time.', required=False)  
   return parser
 
 def messagesForArgs(logFileFlag, fileNameFlag):

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -109,7 +109,7 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
-  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, nargs='*', help='When activated, Squeakuences will collect files with the given extension(s). Only one extension type is accepted at this time. Include the dot in your argument, such as .fna')  
+  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, nargs='*', help='When activated, Squeakuences will collect files with the given extension(s). To collect files with multiple extensions, simply list them behind each other such as ".fa .fna". Include the dot in your argument, such as ".fna"')  
   return parser
 
 def messagesForArgs(logFileFlag, fileNameFlag, extFlag):

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -109,7 +109,7 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
-  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, help='When activated, Squeakuences will collect files with the given extension. Only one extension type is accepted at this time. Include the dot in your argument, such as .fna')  
+  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, nargs='*', help='When activated, Squeakuences will collect files with the given extension(s). Only one extension type is accepted at this time. Include the dot in your argument, such as .fna')  
   return parser
 
 def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
@@ -121,7 +121,7 @@ def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
     if logFileFlag is True:
       print('You\'ve activated the -l flag.\nA log file with information about each fasta file processed will be written in the output directory.')
     if extFlag != '.fa*':
-      print('You\'ve activated the -e flag.\nFiles with the ' + extFlag + ' extension will be collected for cleaning.')
+      print('You\'ve activated the -e flag.\nFiles with the ' + str(extFlag) + ' extension will be collected for cleaning.')
 
 #####################################################
 # RESOLVE USER INPUT                                #
@@ -153,7 +153,8 @@ def inputList(type, userInput, ext):
   if type == 'file':
     toSqueakify.append(userInput)
   if type == 'directory':
-    toSqueakify = glob.glob(userInput + '/*' + ext)
+    for inputExt in ext:
+      toSqueakify += glob.glob(userInput + '/*' + inputExt)
   for file in toSqueakify:
     index = toSqueakify.index(file)
     toSqueakify[index] = os.path.abspath(file)

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -31,22 +31,30 @@ def main():
   inputType = resolveInput(inputPath)
   print('You\'ve input a ' + inputType + '.')
   toProcess = inputList(inputType, inputPath, fileExtension)
-  fileNameList = getFaNameExt(toProcess)
-  print('The following file(s) will be cleaned: ' + str(fileNameList))
-  print('--------------------------------')
 
-  ouputPath = checkOutputArg(outputPath)
+  if toProcess == []:
+    print('--------------------------------')
+    print('Squeakuences did not find any files with the ' + str(fileExtension) + ' extension at the input location.')
+    print('If this is unexpected, please check your command and try again.')
+    print('Exiting Squeakuences run now.')
 
-  logPath = outputPath + '/log.tsv'
-  if logFlag is True:
-    checkExistingLogFile(logPath)
-  
-  for file in toProcess:
-    squeakify(file, ouputPath, logFlag, logPath, fileNameFlag)
+  else:
+    fileNameList = getFaNameExt(toProcess)
+    print('The following file(s) will be cleaned: ' + str(fileNameList))
     print('--------------------------------')
 
-  print('Ta-da! Squeaky clean sequence ids!')
-  #print('New squeaky clean files and other output files can be found in: ' + outputPath)
+    ouputPath = checkOutputArg(outputPath)
+
+    logPath = outputPath + '/log.tsv'
+    if logFlag is True:
+      checkExistingLogFile(logPath)
+    
+    for file in toProcess:
+      squeakify(file, ouputPath, logFlag, logPath, fileNameFlag)
+      print('--------------------------------')
+
+    print('Ta-da! Squeaky clean sequence ids!')
+    #print('New squeaky clean files and other output files can be found in: ' + outputPath)
 
 def squeakify(file, write, logFlag, logPath, fileNameFlag):
   if logFlag is True:

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -21,10 +21,11 @@ def main():
   outputPath = args.output
   logFlag = args.log
   fileNameFlag = args.addFileName
+  fileExtension = args.fileExt
   
   print('Commencing Squeakuences Cleanup')
   print('================================')
-  messagesForArgs(logFlag, fileNameFlag)
+  messagesForArgs(logFlag, fileNameFlag, fileExtension)
   print('--------------------------------')
 
   inputType = resolveInput(inputPath)
@@ -108,17 +109,19 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
-  parser.add_argument('-e', '--fileExt', metavar='.ext', help='When activated, Squeakuences will collect files with the given extension. Only one extension type is accepted at this time.', required=False)  
+  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, help='When activated, Squeakuences will collect files with the given extension. Only one extension type is accepted at this time.')  
   return parser
 
-def messagesForArgs(logFileFlag, fileNameFlag):
-  if logFileFlag == fileNameFlag == False:
+def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
+  if logFileFlag == fileNameFlag == False and extFlag == '.fa*':
     print('No flags detected in command.')
   else:
     if fileNameFlag is True:
       print('You\'ve activated the -f flag.\nThe file name will be inserted at the beginning of all sequences cleaned.')
     if logFileFlag is True:
       print('You\'ve activated the -l flag.\nA log file with information about each fasta file processed will be written in the output directory.')
+    if extFlag is not '.fa*':
+      print('You\'ve activated the -e flag.\nFiles with the ' + extFlag + ' extension will be collected for cleaning.')
 
 #####################################################
 # RESOLVE USER INPUT                                #

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -109,7 +109,7 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
-  parser.add_argument('-e', '--fileExt', metavar='.ext', default = ['.fa*'], required=False, nargs='*', help='When activated, Squeakuences will collect files with the given extension(s). To collect files with multiple extensions, simply list them behind each other such as ".fa .fna". Include the dot in your argument, such as ".fna"')  
+  parser.add_argument('-e', '--fileExt', metavar='.ext', default = ['.fa*'], required=False, nargs='*', help='When activated, Squeakuences will collect files with the provided extension(s). To collect files with multiple extensions, simply list them behind each other such as ".fa .fna". Include the dot in your argument, such as ".fna"')  
   return parser
 
 def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
@@ -158,6 +158,7 @@ def inputList(type, userInput, ext):
   for file in toSqueakify:
     index = toSqueakify.index(file)
     toSqueakify[index] = os.path.abspath(file)
+  toSqueakify.sort()
   return toSqueakify
 
 def getFaNameExt(inputList):

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -109,18 +109,18 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
-  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, nargs='*', help='When activated, Squeakuences will collect files with the given extension(s). To collect files with multiple extensions, simply list them behind each other such as ".fa .fna". Include the dot in your argument, such as ".fna"')  
+  parser.add_argument('-e', '--fileExt', metavar='.ext', default = ['.fa*'], required=False, nargs='*', help='When activated, Squeakuences will collect files with the given extension(s). To collect files with multiple extensions, simply list them behind each other such as ".fa .fna". Include the dot in your argument, such as ".fna"')  
   return parser
 
 def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
-  if logFileFlag == fileNameFlag == False and extFlag == '.fa*':
+  if logFileFlag == fileNameFlag == False and extFlag == ['.fa*']:
     print('No flags detected in command.')
   else:
     if fileNameFlag is True:
       print('You\'ve activated the -f flag.\nThe file name will be inserted at the beginning of all sequences cleaned.')
     if logFileFlag is True:
       print('You\'ve activated the -l flag.\nA log file with information about each fasta file processed will be written in the output directory.')
-    if extFlag != '.fa*':
+    if extFlag != ['.fa*']:
       print('You\'ve activated the -e flag.\nFiles with the ' + str(extFlag) + ' extension will be collected for cleaning.')
 
 #####################################################

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -109,7 +109,7 @@ def setupParser():
                                                 If this directory path does not exist at runtime, Squeakuences will create it for you.''', required=True)
   parser.add_argument('-l', '--log', help='When activated, Squeakuences will generate a log file with processing info from each fasta file cleaned.', required=False, action='store_true')
   parser.add_argument('-f', '--addFileName', help='When activated, Squeakuences will add the file name to the beginning of all sequences cleaned.', required=False, action='store_true')
-  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, help='When activated, Squeakuences will collect files with the given extension. Only one extension type is accepted at this time.')  
+  parser.add_argument('-e', '--fileExt', metavar='.ext', default = '.fa*', required=False, help='When activated, Squeakuences will collect files with the given extension. Only one extension type is accepted at this time. Include the dot in your argument, such as .fna')  
   return parser
 
 def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
@@ -120,7 +120,7 @@ def messagesForArgs(logFileFlag, fileNameFlag, extFlag):
       print('You\'ve activated the -f flag.\nThe file name will be inserted at the beginning of all sequences cleaned.')
     if logFileFlag is True:
       print('You\'ve activated the -l flag.\nA log file with information about each fasta file processed will be written in the output directory.')
-    if extFlag is not '.fa*':
+    if extFlag != '.fa*':
       print('You\'ve activated the -e flag.\nFiles with the ' + extFlag + ' extension will be collected for cleaning.')
 
 #####################################################


### PR DESCRIPTION
add new flag which allows user to specify what file extensions to collect for squeakification

example: ./squeakuences.py -i fna_files -o fna_faa_both_OUT -e .faa .fna
will collect files with the .faa and .fna file extensions

if -e flag is not passed, squeakuences defaults to all file extensions that begin with '.fa'