### PR TITLE
Refactor squeak.fa write implementation

### DIFF
--- a/squeakuences.py
+++ b/squeakuences.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import cProfile
 import argparse
 import re
 import os
@@ -333,4 +334,4 @@ def writeLogFile(logDataDict, logPath, processedIdCount):
   file.close()
 
 if __name__ == '__main__':
-  main()
+  cProfile.run('main()', sort='tottime')

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import cProfile
 import argparse
 import re
 import os
@@ -351,4 +350,4 @@ def writeLogFile(logDataDict, logPath, processedIdCount):
   file.close()
 
 if __name__ == '__main__':
-  cProfile.run('main()', sort='tottime')
+  main()

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -289,7 +289,7 @@ def resolveDuplicate(startSequenceId, modSequenceId, dupsList):
 
 def storeLine(outFaFileLines, line, sequence):
     if sequence is True:
-      outFaFileLines.append('>' + line)
+      outFaFileLines.append('>' + line + '\n')
     else:
       outFaFileLines.append(line)
 

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -287,16 +287,6 @@ def resolveDuplicate(startSequenceId, modSequenceId, dupsList):
   dupsList.append(modSequenceId)
   return startDupId, endDupId
 
-'''
-def writeLine(faFile, line, sequence):
-  with open(faFile, 'a') as file:
-    if sequence is True:
-      file.write('>' + line + '\n')
-    else:
-      file.write(line)
-  file.close()
-'''
-
 def storeLine(outFaFileLines, line, sequence):
     if sequence is True:
       outFaFileLines.append('>' + line)

--- a/squeakuences.py
+++ b/squeakuences.py
@@ -57,6 +57,8 @@ def squeakify(file, write, logFlag, logPath, fileNameFlag):
   idDict = {}
   idDuplicatesList = []
 
+  cleanedFaLines = []
+
   faFileNameExt, fastaHandle, faFileName = loadFile(file)
   print('Now processing ' + faFileNameExt)
 
@@ -84,10 +86,12 @@ def squeakify(file, write, logFlag, logPath, fileNameFlag):
         
       idDict.update({startId: endId})
 
-      writeLine(squeakyPath, endId, True)
+      storeLine(cleanedFaLines, endId, True)
 
     else:
-      writeLine(squeakyPath, line, False)
+      storeLine(cleanedFaLines, line, False)
+  
+  writeNewFaFile(squeakyPath, cleanedFaLines)
 
   writeModIdFile(write + '/' + faFileName, idDict)
 
@@ -284,6 +288,7 @@ def resolveDuplicate(startSequenceId, modSequenceId, dupsList):
   dupsList.append(modSequenceId)
   return startDupId, endDupId
 
+'''
 def writeLine(faFile, line, sequence):
   with open(faFile, 'a') as file:
     if sequence is True:
@@ -291,6 +296,18 @@ def writeLine(faFile, line, sequence):
     else:
       file.write(line)
   file.close()
+'''
+
+def storeLine(outFaFileLines, line, sequence):
+    if sequence is True:
+      outFaFileLines.append('>' + line)
+    else:
+      outFaFileLines.append(line)
+
+def writeNewFaFile(newFilePath, cleanedLinesList):
+  f = open(newFilePath, 'w')
+  f.writelines(cleanedLinesList)
+  f.close()
   
 def writeModIdFile(faFileName, idDictInput):
   fileExtension = os.path.splitext(faFileName)


### PR DESCRIPTION
Speed up the runtime of squeakuences by changing how squeak.fa is written. It is now written all at once instead of line by line as squeakuences cleans lines.