### PR TITLE
Fix error out when -f flag is active

### DIFF
--- a/squeakuences/squeakify.py
+++ b/squeakuences/squeakify.py
@@ -1,6 +1,6 @@
 import re
 
-def squeakify(sequenceID, argsFlags):
+def squeakify(sequenceID, argsFlags, fastaFileName):
   checkWhiteSpace(sequenceID)
 
   endID = camelCase(sequenceID)
@@ -8,7 +8,7 @@ def squeakify(sequenceID, argsFlags):
   endID = removeNonAlphanumeric(endID, argsFlags['ignore'], argsFlags['underscore'])
   
   if argsFlags['addFileName'] is True:
-    endID = attachFileName(endID, argsFlags['addFileName'])
+    endID = attachFileName(endID, fastaFileName, argsFlags)
 
   if argsFlags['chopMethod'] != 'skip':
     endID = checkLength(endID, argsFlags['chopMax'], argsFlags['chopMethod'])
@@ -54,10 +54,10 @@ def removeNonAlphanumeric(sequenceID, ignore, underscore):
     modifiedID = re.sub(customRegex, '_', sequenceID)
   return modifiedID
 
-def attachFileName(sequenceID, attachFileName):
+def attachFileName(sequenceID, attachFileName, argsFlags):
   attachFileName = camelCase(attachFileName)
-  attachFileName = removeSpaces(attachFileName)
-  attachFileName = removeNonAlphanumeric(attachFileName)
+  attachFileName = removeSpaces(attachFileName, argsFlags['underscore'])
+  attachFileName = removeNonAlphanumeric(attachFileName,argsFlags['ignore'], argsFlags['underscore'])
   sequenceIDLower = sequenceID.lower()
   attachFileNameLower = attachFileName.lower()
 

--- a/squeakuences/squeaky_file.py
+++ b/squeakuences/squeaky_file.py
@@ -30,7 +30,7 @@ def generate(file, argsDict):
       sequenceIdCount += 1
       sequenceID = squeakify.stripSequenceID(line)
 
-      cleanSequenceId = squeakify.squeakify(sequenceID, argsDict)
+      cleanSequenceId = squeakify.squeakify(sequenceID, argsDict, currentFaFileName)
 
       if checkForDuplicates(cleanSequenceId, idDict):
         sequenceID, cleanSequenceId = resolveDuplicate(sequenceID, cleanSequenceId, idDuplicatesList)


### PR DESCRIPTION
Addresses issue #56 in which user activated -f flag in their command, and Squeakuences quit due to a type error in function which prepends the file name.