### PR TITLE
Patch issue #60, inaccurate -f flag behavior when -p is also activated

### DIFF
--- a/squeakuences/preview.py
+++ b/squeakuences/preview.py
@@ -4,6 +4,7 @@ import squeakify
 
 def generatePreview(file, argsDict):
   fileNameWithExt = file_system.fileNameWithExt(file)
+  fileNameOnly = file_system.fileNameOnly(file)
   print('Now generating preview of cleaned sequence ids from: ' + fileNameWithExt)
   print()
 
@@ -14,7 +15,7 @@ def generatePreview(file, argsDict):
     if line.startswith('>'):
       sequenceID = squeakify.stripSequenceID(line)
 
-      cleanSequenceId = squeakify.squeakify(sequenceID, argsDict, fileNameWithExt)
+      cleanSequenceId = squeakify.squeakify(sequenceID, argsDict, fileNameOnly)
 
       print(cleanSequenceId)
     linecount += 1


### PR DESCRIPTION
Edit file name parameter in squeakify call on line 18 in preview.py from file name with extension to only the file name to prevent 'GalgalFaa_Galgal_1_Phosphatidylinositol____Beta_3_Like' error