### PR TITLE
Issues #64 and #65

### DIFF
--- a/squeakuences/cli.py
+++ b/squeakuences/cli.py
@@ -44,7 +44,7 @@ def runParser():
     Please provide the characters you would like to leave in sequence ids in single or double quotes such as "-,()". 
     If included, the underscore character must be at the front of your input string.''')
   
-  parser.add_argument('-r', '--retain', action='store', default = None, required=False, metavar='string',
+  parser.add_argument('-r', '--retain', action='store', default = None, required=False, metavar='tag',
     help='''When activated, Squeakuences will retain tag information in the sequence id such as "locus=abc123". 
     The information in this tag will not be cleaned and appended to the end of the cleaned sequence id. Pass in the tag name in the format of -r 'locus='.''')
   

--- a/squeakuences/cli.py
+++ b/squeakuences/cli.py
@@ -46,7 +46,8 @@ def runParser():
   
   parser.add_argument('-r', '--retain', action='store', default = None, required=False, metavar='tag',
     help='''When activated, Squeakuences will retain tag information in the sequence id such as "locus=abc123". 
-    The information in this tag will not be cleaned and appended to the end of the cleaned sequence id. Pass in the tag name in the format of -r 'locus='.''')
+    The information in this tag will not be cleaned and appended to the end of the cleaned sequence id. Pass in the tag name in the format of -r 'locus='. 
+    Cleaned sequence id may exceed character limit. Length check occurs before tag is appended.''')
   
   return parser.parse_args()
 

--- a/squeakuences/cli.py
+++ b/squeakuences/cli.py
@@ -34,7 +34,7 @@ def runParser():
     help='When activated, Squeakuences will set the maximum character length of cleaned sequence ids to this integer.')
   
   parser.add_argument('-p', '--preview', action='store_true', default = False, required=False,
-    help='When activated, Squeakuences will generate a preview of 10 cleaned sequences from the top of each input file.')
+    help='When activated, Squeakuences will generate a preview of 15 cleaned sequences from the top of each input file.')
   
   parser.add_argument('-u', '--underscore', action='store_true', default = None, required=False,
     help='When activated, Squeakuences will replace whitespace (spaces and tabs) and non-alphanumeric characters with an underscore.')

--- a/squeakuences/cli.py
+++ b/squeakuences/cli.py
@@ -44,6 +44,10 @@ def runParser():
     Please provide the characters you would like to leave in sequence ids in single or double quotes such as "-,()". 
     If included, the underscore character must be at the front of your input string.''')
   
+  parser.add_argument('-r', '--retain', action='store', default = None, required=False, metavar='string',
+    help='''When activated, Squeakuences will retain tag information in the sequence id such as "locus=abc123". 
+    The information in this tag will not be cleaned and appended to the end of the cleaned sequence id. Pass in the tag name in the format of -r 'locus='.''')
+  
   return parser.parse_args()
 
 def setDefaults(argsDict):
@@ -71,8 +75,11 @@ def setDefaults(argsDict):
   if argsDict['ignore'] is None:
     argsDict.update({'ignore': None})
 
+  if argsDict['retain'] is None:
+    argsDict.update({'retain': None})
+
 def messagesForArgs(argsDict):
-  if argsDict['chopMethod'] == argsDict['fileExt'] == argsDict['addFileName'] == argsDict['log'] == argsDict['chopMax'] == argsDict['underscore'] == argsDict['ignore'] == None  and argsDict['preview'] == False:
+  if argsDict['chopMethod'] == argsDict['fileExt'] == argsDict['addFileName'] == argsDict['log'] == argsDict['chopMax'] == argsDict['underscore'] == argsDict['ignore'] == argsDict['retain'] == None  and argsDict['preview'] == False:
     print('No flags detected in command.')
   else:
     if argsDict['chopMethod'] == 'words' or argsDict['chopMethod'] == 'chars':
@@ -93,6 +100,8 @@ def messagesForArgs(argsDict):
       print('You\'ve activated the -u flag.\nSqueakuences will replace whitespace (spaces and tabs) and nonalphanumeric characters with an underscore.')
     if argsDict['ignore'] != None:
       print('You\'ve activated the -x flag.\nSqueakuences will ignore ' + argsDict['ignore'] + ' characters during cleaning.')
+    if argsDict['retain'] != None:
+      print('You\'ve activated the -r flag.\nSqueakuences will retain the information in the ' + argsDict['retain'] + ' tag and append to the end after cleaning.')
 
 def printArgumentState(argsDict):
   print('Squeakuences will clean sequence ids will the following settings:\n')
@@ -101,6 +110,7 @@ def printArgumentState(argsDict):
   print('Prepend file name (-f): ' + str(argsDict['addFileName']))
   print('Underscores (-u): ' + str(argsDict['underscore']))
   print('Ignore characters (-x): ' + str(argsDict['ignore']))
+  print('Retain tag (-r): ' + str(argsDict['retain']))
   print('--------------------------------')
 
 def resolveInputType(userInput):

--- a/squeakuences/preview.py
+++ b/squeakuences/preview.py
@@ -3,6 +3,7 @@ import file_system
 import squeakify
 
 def generatePreview(file, argsDict):
+  previewCounter = 0
   fileNameWithExt = file_system.fileNameWithExt(file)
   fileNameOnly = file_system.fileNameOnly(file)
   print('Now generating preview of cleaned sequence ids from: ' + fileNameWithExt)
@@ -10,12 +11,19 @@ def generatePreview(file, argsDict):
 
   messyFastaHandle = file_system.loadMessyFile(file)
 
-  for linecount in range(30):
-    line = next(messyFastaHandle).strip()
-    if line.startswith('>'):
-      sequenceID = squeakify.stripSequenceID(line)
+  while previewCounter < 15:
+    try: 
+      line = next(messyFastaHandle)
+    
+    except:
+      break
 
-      cleanSequenceId = squeakify.squeakify(sequenceID, argsDict, fileNameOnly)
+    else:
+      line.strip()
+      if line.startswith('>'):
+        previewCounter += 1
+        sequenceID = squeakify.stripSequenceID(line)
 
-      print(cleanSequenceId)
-    linecount += 1
+        cleanSequenceId = squeakify.squeakify(sequenceID, argsDict, fileNameOnly)
+
+        print(cleanSequenceId)

--- a/squeakuences/squeakify.py
+++ b/squeakuences/squeakify.py
@@ -1,6 +1,10 @@
 import re
 
 def squeakify(sequenceID, argsFlags, fastaFileName):
+  if argsFlags['retain'] is not None:
+    retainTag = re.search(r'(locus=\S+)', sequenceID).group()
+    sequenceID = sequenceID.replace(retainTag, '')
+
   checkWhiteSpace(sequenceID)
 
   endID = camelCase(sequenceID)
@@ -14,6 +18,11 @@ def squeakify(sequenceID, argsFlags, fastaFileName):
     endID = checkLength(endID, argsFlags['chopMax'], argsFlags['chopMethod'])
 
   endID = removeSpaces(endID, argsFlags['underscore'])
+
+  if argsFlags['retain'] is not None:
+    info = retainTag.split('=')[1]
+    info = '_'+ info
+    endID = endID + info
 
   return endID
 

--- a/squeakuences/squeakify.py
+++ b/squeakuences/squeakify.py
@@ -2,7 +2,8 @@ import re
 
 def squeakify(sequenceID, argsFlags, fastaFileName):
   if argsFlags['retain'] is not None:
-    retainTag = re.search(r'(locus=\S+)', sequenceID).group()
+    regex = r'(' + argsFlags['retain'] + '\S+)'
+    retainTag = re.search(regex, sequenceID).group()
     sequenceID = sequenceID.replace(retainTag, '')
 
   checkWhiteSpace(sequenceID)


### PR DESCRIPTION
fixes #64 so 15 seq id previews are generated unless there are less than 15 '>' lines regardless of length of sequences

closes #65 by implementing a retaining feature which saves and appends unaltered information from one tag to the end of cleaned sequence id